### PR TITLE
Pin django-allauth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gunicorn
 pillow
 pillow-avif-plugin
 django-csp
+django-allauth==0.63.6


### PR DESCRIPTION
## Summary
- pin `django-allauth` to a version that still contains `assess_unique_email`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a59c0d3a08331b9be9ed9659cbfb3